### PR TITLE
Upgrade all dotnet packages to latest

### DIFF
--- a/src/NosCore.ReverseProxy/NosCore.ReverseProxy.csproj
+++ b/src/NosCore.ReverseProxy/NosCore.ReverseProxy.csproj
@@ -24,8 +24,8 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
 		<PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
-		<PackageReference Include="NosCore.Packets" Version="15.0.0" />
-		<PackageReference Include="NosCore.Shared" Version="5.0.0" />
+		<PackageReference Include="NosCore.Packets" Version="16.0.0" />
+		<PackageReference Include="NosCore.Shared" Version="6.0.0" />
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
 		<!-- Explicit references to fix security vulnerabilities in transitive dependencies -->
 		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />


### PR DESCRIPTION
- Upgrade NosCore.Packets from 15.0.0 to 16.0.0
- Upgrade NosCore.Shared from 5.0.0 to 6.0.0

All other packages were already at their latest versions.