### PR TITLE
chore: support local NuGet source via NOSCORE_LOCAL_PACKAGES env var

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup Condition="'$(NOSCORE_LOCAL_PACKAGES)' != ''">
+    <RestoreAdditionalProjectSources>$(RestoreAdditionalProjectSources);$(NOSCORE_LOCAL_PACKAGES)</RestoreAdditionalProjectSources>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Adds `Directory.Build.props` with a conditional `RestoreAdditionalProjectSources` that activates only when `NOSCORE_LOCAL_PACKAGES` is set.
- No runtime cost for contributors who don't opt in — the property group is skipped, restore uses nuget.org only.
- To use: `setx NOSCORE_LOCAL_PACKAGES C:\LocalPackages`, restart shell/VS, drop .nupkg files into the folder.

## Test plan
- [ ] `dotnet restore` succeeds with `NOSCORE_LOCAL_PACKAGES` unset.
- [ ] `dotnet restore` with `NOSCORE_LOCAL_PACKAGES` pointing to a folder with a .nupkg picks it up.

Generated with [Claude Code](https://claude.com/claude-code)